### PR TITLE
Build 📦: Turn typechecking and linting nextjs

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -20,6 +20,16 @@ const config = {
   },
   images: {
     domains: ["images.clerk.dev", "res.cloudinary.com"]
-  }
+  },
+
+  // Ignore linting and typescript, doing that through GitHub CI
+  typescript: {
+    ignoreBuildErrors: true,
+  },
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  swcMinify: true,
+
 };
 export default config;


### PR DESCRIPTION
I'm doing typechecking and linting in GitHub CI so I've turned it off for vercel.

Using swcMinify for faster builds.